### PR TITLE
fix: address maxLength values

### DIFF
--- a/src/components/dashboard/MembersList.tsx
+++ b/src/components/dashboard/MembersList.tsx
@@ -1,4 +1,4 @@
-import { Address } from '@/src/components/ui/Address';
+import { Address, AddressLength } from '@/src/components/ui/Address';
 import { Card } from '@/src/components/ui/Card';
 import { Member } from '@/src/hooks/useMembers';
 import { CHAIN_METADATA } from '@/src/lib/constants/chains';
@@ -22,7 +22,7 @@ const MemberCard = ({ member }: { member: Member }) => {
         <Address
           address={member.address}
           hasLink={true}
-          maxLength={20}
+          maxLength={AddressLength.Medium}
           showCopy={false}
         />
       </div>

--- a/src/components/governance/ProposalCard.tsx
+++ b/src/components/governance/ProposalCard.tsx
@@ -1,14 +1,8 @@
 import { Card } from '@/src/components/ui/Card';
-import { Address } from '@/src/components/ui//Address';
+import { Address, AddressLength } from '@/src/components/ui//Address';
 import Header from '@/src/components/ui/Header';
-import { cn } from '@/src/lib/utils';
-import { cva } from 'class-variance-authority';
-import DoubleCheck from '@/src/components/icons/DoubleCheck';
-import Check from '@/src/components/icons/Check';
 import { ProposalStatus } from '@aragon/sdk-client';
 import { Proposal } from '@/src/hooks/useProposals';
-import { HiChevronRight, HiOutlineClock, HiXMark } from 'react-icons/hi2';
-import Activity from '@/src/components/icons/Actitivy';
 import ProposalTag, {
   ProposalTagProps,
 } from '@/src/components/governance/ProposalTag';
@@ -90,7 +84,7 @@ const ProposalCard = ({ proposal }: { proposal: Proposal }) => {
         <span className="text-gray-500 dark:text-slate-400">Published by</span>
         <Address
           address={creatorAddress}
-          maxLength={16}
+          maxLength={AddressLength.Medium}
           hasLink={true}
           showCopy={true}
         />

--- a/src/components/proposal/VotesContent.tsx
+++ b/src/components/proposal/VotesContent.tsx
@@ -17,7 +17,7 @@ import { useForm, SubmitHandler, UseFormRegister } from 'react-hook-form';
 import { useAragonSDKContext } from '@/src/context/AragonSDK';
 import { useCanVote } from '@/src/hooks/useCanVote';
 import { useAccount } from 'wagmi';
-import { Address } from '@/src/components/ui/Address';
+import { Address, AddressLength } from '@/src/components/ui/Address';
 
 type VoteFormData = {
   vote_value: string;
@@ -185,7 +185,7 @@ const VoteOption = ({
               >
                 <Address
                   address={vote.address}
-                  maxLength={14}
+                  maxLength={AddressLength.Small}
                   hasLink={true}
                   showCopy={false}
                   replaceYou={false}

--- a/src/components/ui/Address.stories.tsx
+++ b/src/components/ui/Address.stories.tsx
@@ -16,7 +16,7 @@ export const Medium: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.medium}
+      maxLength={AddressLength.Medium}
       hasLink={true}
       showCopy={true}
     />
@@ -27,7 +27,7 @@ export const Small: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.small}
+      maxLength={AddressLength.Small}
       hasLink={true}
       showCopy={true}
     />
@@ -38,7 +38,7 @@ export const Large: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.large}
+      maxLength={AddressLength.Large}
       hasLink={true}
       showCopy={true}
     />
@@ -49,7 +49,7 @@ export const Full: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.full}
+      maxLength={AddressLength.Large}
       hasLink={true}
       showCopy={true}
     />
@@ -60,7 +60,7 @@ export const NoLink: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.medium}
+      maxLength={AddressLength.Medium}
       hasLink={false}
       showCopy={true}
     />
@@ -71,7 +71,7 @@ export const NoCopy: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.medium}
+      maxLength={AddressLength.Medium}
       hasLink={true}
       showCopy={false}
     />
@@ -82,10 +82,9 @@ export const NoLinkNoCopy: Story = {
   render: () => (
     <Address
       address={exampleAddress}
-      maxLength={AddressLength.medium}
+      maxLength={AddressLength.Medium}
       hasLink={false}
       showCopy={false}
     />
   ),
 };
-

--- a/src/components/ui/Address.tsx
+++ b/src/components/ui/Address.tsx
@@ -6,10 +6,10 @@ import { useAccount } from 'wagmi';
 
 //TODO improve this (hidde will make it way better later)
 export enum AddressLength {
-  small = 10,
-  medium = 20,
-  large = 40,
-  full = -1, //Any negative number means no trunction
+  Small = 10,
+  Medium = 20,
+  Large = 40,
+  Full = -1, // no trunction
 }
 
 type AddressProps = {

--- a/src/pages/Finance.tsx
+++ b/src/pages/Finance.tsx
@@ -1,6 +1,6 @@
 import { TransferType } from '@aragon/sdk-client';
 import { HiArrowSmallRight } from 'react-icons/hi2';
-import { Address } from '../components/ui/Address';
+import { Address, AddressLength } from '../components/ui/Address';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
 import { HeaderCard } from '../components/ui/HeaderCard';
@@ -47,7 +47,7 @@ const DaoTokens = ({
             <span>
               <Address
                 address={balance.address ?? '-'}
-                maxLength={10}
+                maxLength={AddressLength.Small}
                 hasLink={true}
                 showCopy={true}
               />
@@ -115,7 +115,7 @@ export const DaoTransfers = ({
               />
               <Address
                 address={daoTransferAddress(transfer)}
-                maxLength={10}
+                maxLength={AddressLength.Small}
                 hasLink={true}
                 showCopy={true}
               />

--- a/src/pages/ViewProposal.tsx
+++ b/src/pages/ViewProposal.tsx
@@ -1,7 +1,7 @@
 import { HeaderCard } from '@/src/components/ui/HeaderCard';
 import { useProposal } from '@/src/hooks/useProposal';
 import { useParams } from 'react-router';
-import { Address } from '@/src/components/ui/Address';
+import { Address, AddressLength } from '@/src/components/ui/Address';
 import { ProposalStatusBadge } from '@/src/components/governance/ProposalCard';
 import { Card } from '@/src/components/ui/Card';
 import Header from '@/src/components/ui/Header';
@@ -45,7 +45,7 @@ const ViewProposal = () => {
                   </span>
                   <Address
                     address={proposal.creatorAddress}
-                    maxLength={16}
+                    maxLength={AddressLength.Medium}
                     hasLink={true}
                     showCopy={false}
                   />


### PR DESCRIPTION
Fix error where the value for prop `maxLength` in the `Address` component was not valid due to a change of the type of that prop