### PR TITLE
feat: replace WYSIWYG with purify DOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.4.0",
         "clsx": "^1.2.1",
         "date-fns": "^2.29.3",
+        "dompurify": "^3.0.1",
         "dotenv": "^16.0.3",
         "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -14610,6 +14611,11 @@
       "dependencies": {
         "domelementtype": "1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "class-variance-authority": "^0.4.0",
     "clsx": "^1.2.1",
     "date-fns": "^2.29.3",
+    "dompurify": "^3.0.1",
     "dotenv": "^16.0.3",
     "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/src/components/newProposal/viewProposal/ViewStepOne.stories.tsx
+++ b/src/components/newProposal/viewProposal/ViewStepOne.stories.tsx
@@ -28,6 +28,25 @@ export const Primary: Story = {
   },
 };
 
+export const RichHtml: Story = {
+  args: {
+    data: {
+      title: 'A nice title for a proposal with a rich description',
+      summary: 'This is a proposal ',
+      description:
+        '<p>This is richt text content</p><p><strong>This line is bold</strong></p><p><em>This is in italics</em></p><p><a target="_blank" rel="noopener noreferrer nofollow" href="http://www.example.com">This is a link</a></p><ul><li><p>We even have lists</p></li><li><p>With multiple elements</p></li><li><p>This one is numbered</p></li></ul><p>But we can also have bullet point lists</p><ol><li><p>Bullet 1</p></li><li><p>Bullet 2</p></li><li><p>Last bullet 3</p></li></ol><p></p>',
+      resources: [
+        { name: 'Example resource 1', url: 'https:://www.example.com/1' },
+        { name: 'Example resource 2', url: 'https:://www.example.com/2' },
+      ],
+      media: {
+        logo: '',
+        header: '',
+      },
+    },
+  },
+};
+
 export const Undefined: Story = {
   args: {
     data: undefined,

--- a/src/components/newProposal/viewProposal/ViewStepOne.tsx
+++ b/src/components/newProposal/viewProposal/ViewStepOne.tsx
@@ -7,23 +7,23 @@
  */
 
 import { HeaderCard } from '../../ui/HeaderCard';
-import { TextareaWYSIWYG } from '../../ui/TextareaWYSIWYG';
 import { StepOneMetadata } from '../newProposalData';
+import DOMPurify from 'dompurify';
 
 export const ViewStepOne = ({
   data,
 }: {
   data: StepOneMetadata | undefined;
 }) => {
+  const htmlClean = DOMPurify.sanitize(
+    data?.description ?? '<p>Proposal has no description </p>'
+  );
+
   return (
     <HeaderCard variant="light" title={data?.title ?? 'Proposal has no title'}>
       <h3 className="text-xl">{data?.summary ?? 'Proposal has no summary'} </h3>
-      <TextareaWYSIWYG
-        setError={() => {}}
-        clearErrors={() => {}}
-        disabled={true}
-        value={data?.description ?? '<p>Proposal has no description </p'}
-      />
+      {/* Note that since our HTML is sanitized, this dangerous action is safe */}
+      <div dangerouslySetInnerHTML={{ __html: htmlClean }} />
     </HeaderCard>
   );
 };


### PR DESCRIPTION
Taken from JIRA task:


Instead of using the WYSIWYG editor, purify the HTML string and then view it.

 

Following this tutorial: https://blog.logrocket.com/using-dangerouslysetinnerhtml-in-a-react-application/

We add the dompurify package: https://www.npmjs.com/package/dompurify

Sanitize data using: const clean = DOMPurify.sanitize(data)

Display html using: dangerouslySetInnerHTML={clean}
