### PR TITLE
fix: layout of start/end time inputs

### DIFF
--- a/src/components/newProposal/steps/Voting.tsx
+++ b/src/components/newProposal/steps/Voting.tsx
@@ -185,7 +185,7 @@ export const StartTime = ({
           )}
         />
         {startTimeType === 'custom' && (
-          <Card variant="light">
+          <Card variant="light" className="flex gap-2">
             <LabelledInput
               id="custom_start_date"
               type="date"
@@ -308,7 +308,7 @@ export const EndTime = ({
         />
 
         {endTimeType === 'duration' ? (
-          <Card variant="light">
+          <Card variant="light" className="flex gap-2">
             <LabelledInput
               id="duration_days"
               type="number"
@@ -320,6 +320,7 @@ export const EndTime = ({
               }
               max="364"
               error={errors.duration_days}
+              className="text-center"
             />
             <LabelledInput
               id="duration_hours"
@@ -336,6 +337,7 @@ export const EndTime = ({
               }
               max="23"
               error={errors.duration_hours}
+              className="text-center"
             />
             <LabelledInput
               id="duration_minutes"
@@ -352,11 +354,12 @@ export const EndTime = ({
               }
               max="59"
               error={errors.duration_minutes}
+              className="text-center"
             />
           </Card>
         ) : (
           endTimeType === 'end-custom' && (
-            <Card variant="light">
+            <Card variant="light" className="flex gap-2">
               <LabelledInput
                 id="custom_end_date"
                 type="date"

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -54,11 +54,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = 'Input';
 
-export interface LabelledInputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface LabelledInputProps extends InputProps {
   id: string;
   label: string;
-  error?: FieldError;
 }
 
 const LabelledInput = React.forwardRef<HTMLInputElement, LabelledInputProps>(
@@ -73,7 +71,7 @@ const LabelledInput = React.forwardRef<HTMLInputElement, LabelledInputProps>(
             error={error}
             placeholder={label}
             {...props}
-            className={cn('w-full text-center', className)}
+            className={cn('w-full', className)}
           />
         </ErrorWrapper>
       </div>

--- a/src/components/ui/TimeZoneSelector.tsx
+++ b/src/components/ui/TimeZoneSelector.tsx
@@ -69,7 +69,7 @@ export const TimezoneSelector = ({
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectLabel>UTC</SelectLabel>
+              <SelectLabel>Timezone</SelectLabel>
               {generateUtcOptions().map((value) => (
                 <SelectItem key={value} value={value}>
                   {value}


### PR DESCRIPTION
# Type of change

Fix

#### Does it contain breaking changes?

No

# Description

Fixed issue where the content of the RadioButtonCard's  on the new-proposal voting page were not correctly shown (did not have flex)

# Changes

- [x] Fixed layout of RadioButtonCard's on new-proposal voting page
