### PR TITLE
Fix passed voting power to vote SDK function

### DIFF
--- a/src/components/proposal/VotesContent.tsx
+++ b/src/components/proposal/VotesContent.tsx
@@ -119,12 +119,12 @@ const VotesContentActive = ({
 }) => {
   const { handleSubmit, watch, control } = useForm<VoteFormData>();
   const { isConnected, address } = useAccount();
-  const { getVotingPower, votingPower } = useVotingPower({ address });
+  const { getProposalVotingPower, votingPower } = useVotingPower({ address });
 
   const onSubmitVote: SubmitHandler<VoteFormData> = async (data) => {
     try {
       // Fetch most recent voting power, to vote with all available rep
-      const votingPower = await getVotingPower();
+      const votingPower = await getProposalVotingPower(proposal);
       if (votingPower.lte(0)) {
         return toast({
           variant: 'error',


### PR DESCRIPTION
Fetches voting power specifically for a given proposal, and makes sure this does not exceed the maximum voting power of the proposal.
Previously, just the current voting power would be passed to the vote function, while this should be the voting power at the time of the creation of the proposal. It also did not take into account the max voting power per wallet for a given proposal. Both of these should now be handled correctly

