### PR TITLE
Feat allow decimal mint tokens

### DIFF
--- a/src/components/newProposal/actions/MintTokensInput.stories.tsx
+++ b/src/components/newProposal/actions/MintTokensInput.stories.tsx
@@ -25,7 +25,7 @@ export const Primary: Story = {
         {
           name: 'mint_tokens',
           wallets: [
-            { address: '0x123456789012345678901234567890', amount: 321 },
+            { address: '0x123456789012345678901234567890', amount: '321' },
           ],
         },
       ],

--- a/src/components/newProposal/actions/MintTokensInput.tsx
+++ b/src/components/newProposal/actions/MintTokensInput.tsx
@@ -34,12 +34,12 @@ export interface ProposalFormMintData extends ProposalFormAction {
 
 export type ProposalFormMintWallet = {
   address: string;
-  amount: number;
+  amount: string;
 };
 
 export const emptyMintWallet: ProposalFormMintWallet = {
   address: '',
-  amount: 0,
+  amount: '0',
 };
 
 export const emptyMintData: ProposalFormMintData = {
@@ -106,7 +106,7 @@ export const MintTokensInput = () => {
         type="button"
         label="Add wallet"
         icon={HiPlus}
-        onClick={() => append({ address: '', amount: 0 })}
+        onClick={() => append({ address: '', amount: '0' })}
       />
     </MainCard>
   );
@@ -169,12 +169,10 @@ const MintListItem = ({
                 message: 'Please enter a number, e.g. 3.141',
               },
             })}
-            type="number"
             id="tokens"
             error={errors?.amount}
             className="w-full basis-2/3"
             min="0"
-            step="1" // Only allow integers
             required
           />
         </ErrorWrapper>

--- a/src/components/newProposal/actions/MintTokensInput.tsx
+++ b/src/components/newProposal/actions/MintTokensInput.tsx
@@ -168,11 +168,14 @@ const MintListItem = ({
                 value: NumberPattern,
                 message: 'Please enter a number, e.g. 3.141',
               },
+              valueAsNumber: false,
             })}
             id="tokens"
             error={errors?.amount}
             className="w-full basis-2/3"
             min="0"
+            step="0.001"
+            type="number"
             required
           />
         </ErrorWrapper>

--- a/src/components/newProposal/steps/Confirmation.stories.tsx
+++ b/src/components/newProposal/steps/Confirmation.stories.tsx
@@ -67,15 +67,15 @@ export const Primary: Story = {
             wallets: [
               {
                 address: '0x23868C8ed12EAD37ef76457e7B6443192e231442',
-                amount: 1,
+                amount: '1',
               },
               {
                 address: '0x23868C8ed12EAD37ef76457e7B6443192e231442',
-                amount: 3.141,
+                amount: '3.141',
               },
               {
                 address: '0x23868C8ed12EAD37ef76457e7B6443192e231442',
-                amount: 1000,
+                amount: '1000',
               },
             ],
           },
@@ -83,7 +83,7 @@ export const Primary: Story = {
             name: 'withdraw_assets',
             recipient: '0x23868C8ed12EAD37ef76457e7B6443192e231442',
             tokenAddress: constants.AddressZero,
-            amount: 3.141,
+            amount: '3.141',
             tokenDecimals: '3',
             tokenType: TokenType.ERC20,
             daoAddress: '0x123',


### PR DESCRIPTION
Changes made:
- Instead of entering a integer, users can now also enter decimal numbers for mint token actions
- the amount for mint tokens form type has been turned into string (needed for precision).
