### PR TITLE
SDK integration for query monetization

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -72,7 +72,7 @@ const navItems: NavItemData[] = [
         label: 'Query',
         url: '/query',
         icon: HiOutlineDocumentMagnifyingGlass,
-        description: `Query the SearchSECO database using your ${TOKENS.secoin.symbol} tokens.}`,
+        description: `Query the SearchSECO database using your ${TOKENS.secoin.symbol} tokens.`,
       },
       {
         label: 'Mining',

--- a/src/hooks/useSearchSECO.ts
+++ b/src/hooks/useSearchSECO.ts
@@ -10,6 +10,10 @@ import { getErrorMessage } from '@/src/lib/utils';
 import { useEffect, useState } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 import { CONFIG } from '@/src/lib/constants/config';
+import { useDiamondSDKContext } from '@/src/context/DiamondGovernanceSDK';
+import { BigNumber, ContractTransaction, ethers } from 'ethers';
+import { erc20ABI } from '../lib/constants/erc20ABI';
+import { parseTokenAmount } from '../lib/utils/token';
 
 type QueryResponse = any;
 type CheckResponse = any;
@@ -28,9 +32,9 @@ type UseSearchSECOData = {
   cost: number | null;
   session: SessionData | null;
   runQuery: (url: string, token: string) => Promise<QueryResponse>;
-  resetQuery: () => void;
+  resetQuery: (clearQueryResult?: boolean) => void;
   startSession: () => Promise<SessionData>;
-  payForSession: (session: SessionData) => Promise<any>;
+  payForSession: (session: SessionData) => Promise<ContractTransaction>;
 };
 
 /**
@@ -178,6 +182,8 @@ export const dummyQueryResult = {
 export const useSearchSECO = (
   props?: UseSearchSECOProps
 ): UseSearchSECOData => {
+  const { client } = useDiamondSDKContext();
+
   const { useDummyData } = Object.assign(defaultProps, props);
   const [queryResult, setQueryResult] = useState<CheckResponse | null>(null);
   const [hashes, setHashes] = useState<string[]>([]);
@@ -338,19 +344,38 @@ export const useSearchSECO = (
    * @param session Session data
    * @returns Promise that resolves when the hashes are paid for
    */
-  const payForSession = async (session: SessionData) => {
-    setSession({
-      ...session,
-      fetch_status: 'success',
-      data: dummyQueryResult,
-    });
+  const payForSession = async (
+    session: SessionData
+  ): Promise<ContractTransaction> => {
+    if (!session) {
+      throw new Error('Session is not defined');
+    }
 
-    setQueryResult(dummyQueryResult);
-    setDoPoll(false);
+    if (!client) {
+      throw new Error('No client found');
+    }
 
-    console.log('Paid for hashes (dummy)');
+    const { id, hashes } = session;
 
-    return Promise.resolve();
+    const IChangeableTokenContract =
+      await client.pure.IChangeableTokenContract();
+    const ERC20Contract = new ethers.Contract(
+      await IChangeableTokenContract.getTokenContractAddress(),
+      erc20ABI,
+      client.pure.signer
+    );
+
+    // Approve the dao to spend the cost of the session
+    const allowanceAmount = parseTokenAmount(session.cost, 18);
+    const tx = await ERC20Contract.approve(
+      client.pure.pluginAddress,
+      allowanceAmount
+    );
+    await tx.wait();
+
+    // Call the actual payForHashes function
+    const monetizationFacet = await client.pure.ISearchSECOMonetizationFacet();
+    return await monetizationFacet.payForHashes(hashes.length, id);
   };
 
   /**
@@ -386,7 +411,7 @@ export const useSearchSECO = (
       }
     } else {
       console.error(sessionRes.error);
-      console.log(session);
+      console.log(sessionRes);
 
       setSession({
         ...session,
@@ -399,10 +424,12 @@ export const useSearchSECO = (
   /**
    * Resets the query state & deletes the session
    */
-  const resetQuery = () => {
-    setQueryResult(null);
-    setHashes([]);
-    setCost(null);
+  const resetQuery = (clearQueryResult: boolean = true) => {
+    if (clearQueryResult) {
+      setQueryResult(null);
+      setCost(null);
+      setHashes([]);
+    }
     setSession(null);
     setSessionId(null);
     setDoPoll(true);

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -186,6 +186,7 @@ type PromiseToast<TData> = {
   success: PromiseProp<TData>;
   error: PromiseProp<unknown>;
   onSuccess?: (data: TData) => void;
+  onError?: (error: unknown) => void;
   onFinish?: () => void;
 };
 
@@ -228,6 +229,9 @@ toast.promise = function <TData>(
       toast.error(promisePropToToast(config.error, error), id);
     }
   );
+  promise.catch((err) => {
+    config.onError && config.onError(err);
+  });
   promise.finally(() => {
     config.onFinish && config.onFinish();
   });
@@ -320,6 +324,7 @@ toast.contractTransaction = async (
   } catch (e) {
     console.error(e);
     toast.error(promisePropToToast(config.error, e), id);
+    config.onError && config.onError(e);
   } finally {
     config.onFinish && config.onFinish();
   }

--- a/src/lib/utils/token.ts
+++ b/src/lib/utils/token.ts
@@ -204,15 +204,15 @@ export const toAbbreviatedTokenAmount = ({
 };
 
 /**
- * Parses a given token amount (string) to a BigNumer token amount, correctly handling decimal places.
+ * Parses a given token amount (string or number) to a BigNumer token amount, correctly handling decimal places.
  * Prefered over ethers.utils.parseUnits because this return null on errors (instead of an exception).
  * Furthermore it cuts off inputs with too many numbers after the decimal point (instead of throwing an exception).
  * Note: If any input is null or undefined it can not parse the value thus null will be returned.
- * @param value Token amount as string (e.g. "123.456")
+ * @param value Token amount as string or number (e.g. "123.456")
  * @param tokenDecimals Number of decimals of the token
  */
 export const parseTokenAmount = (
-  value: string | null | undefined,
+  value: string | number | null | undefined,
   tokenDecimals: number | null | undefined
 ): BigNumber | null => {
   if (
@@ -226,12 +226,17 @@ export const parseTokenAmount = (
 
   let num;
   try {
-    // If the amount of decimals in the value is larger than decimals, it is cut off.
-    if (value.includes('.')) {
-      const values = value.split('.');
-      if (values[1].length > tokenDecimals) {
-        value = `${values[0]}.${values[1].slice(0, tokenDecimals)}`;
+    // Check if num is a string
+    if (typeof value == 'string') {
+      // If the amount of decimals in the value is larger than decimals, it is cut off.
+      if (value.includes('.')) {
+        const values = value.split('.');
+        if (values[1].length > tokenDecimals) {
+          value = `${values[0]}.${values[1].slice(0, tokenDecimals)}`;
+        }
       }
+    } else if (typeof value == 'number') {
+      value = value.toFixed(tokenDecimals);
     }
 
     num = parseUnits(value, tokenDecimals);

--- a/src/pages/Query.tsx
+++ b/src/pages/Query.tsx
@@ -227,22 +227,25 @@ const Query = () => {
                   onClick={async () => {
                     setIsPaying(true);
 
-                    try {
+                    const startAndPaySession = async () => {
                       const session = await startSession();
-                      await payForSession(session);
-                      setPaymentSent(true);
-                    } catch (error: any) {
-                      console.log(error);
+                      return payForSession(session);
+                    };
 
-                      toast.error({
-                        title: error.message.substring(0, 100),
-                      });
-
-                      // Reset session
-                      resetQuery();
-                    }
-
-                    setIsPaying(false);
+                    toast.contractTransaction(startAndPaySession, {
+                      success: 'Paid for session!',
+                      error: 'Failed to pay for session',
+                      onError() {
+                        // Reset session
+                        resetQuery(false);
+                      },
+                      onSuccess() {
+                        setPaymentSent(true);
+                      },
+                      onFinish() {
+                        setIsPaying(false);
+                      },
+                    });
                   }}
                   disabled={!isConnected || isPaying}
                   icon={isPaying ? Loading : null}
@@ -331,7 +334,7 @@ export const CancelButton = ({
   resetQuery,
   setPaymentSent,
 }: {
-  resetQuery: () => void;
+  resetQuery: (clearQueryResult?: boolean) => void;
   // eslint-disable-next-line no-unused-vars
   setPaymentSent: (value: boolean) => void;
 }) => {


### PR DESCRIPTION
# Type of change

Integration

#### Does it contain breaking changes?

No

# Description

Allows the user to pay for hashes on the query page. To actually get this to work you have to run the searchSeco-api server and the SearchSECO database.

# Changes

- [x] Use SDK to pay for hashes
  - [x] Approve SECOIN transfer
  - [x] Call payForHashes
- [x] Add onError to promise toasts
- [x] Fixed some typos
