### PR TITLE
Update verification api url to heroku server

### DIFF
--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -7,7 +7,8 @@
  */
 
 export const CONFIG = {
-  VERIFICATION_API_URL: 'https://securesecodao.science.uu.nl/verification_api',
+  VERIFICATION_API_URL:
+    'https://securesecodao-api.herokuapp.com/verification_api',
   SEARCHSECO_API_URL: 'http://localhost:25566/api',
   DIAMOND_ADDRESS: '0xc57052Bb93BFF80b637A2f5c85Bac28bEa8C5A8d',
   PREFERRED_NETWORK_ID: 80001,


### PR DESCRIPTION
# Type of change

Bug fix

#### Does it contain breaking changes?

No

# Description

Updated the `VERIFICATION_API_URL` in our config to point to the heroku server instead of the UU server