### PR TITLE
Change param action mapping

### DIFF
--- a/src/components/newProposal/actions/ChangeParamInput.tsx
+++ b/src/components/newProposal/actions/ChangeParamInput.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import Loading from '@/src/components/icons/Loading';
 import { Input } from '@/src/components/ui/Input';
 import {
@@ -24,7 +24,6 @@ import { ProposalFormAction } from '@/src/lib/constants/actions';
 import {
   AddressPattern,
   IntegerPattern,
-  NumberPattern,
   SignedIntegerPattern,
 } from '@/src/lib/constants/patterns';
 import { isNullOrUndefined } from '@/src/lib/utils';
@@ -46,6 +45,7 @@ export interface ProposalFormChangeParamData extends ProposalFormAction {
   plugin: string;
   parameter: string;
   value: string;
+  type: string;
 }
 
 export const emptyChangeParamData: ProposalFormChangeParamData = {
@@ -53,6 +53,7 @@ export const emptyChangeParamData: ProposalFormChangeParamData = {
   plugin: '',
   parameter: '',
   value: '',
+  type: '',
 };
 
 // TYPES:
@@ -74,7 +75,7 @@ const addressValidator: Validator = {
 };
 
 const stringValidator: Validator = {
-  validate: (x) => true,
+  validate: (_) => true,
 };
 
 const boolValidator: Validator = {
@@ -149,6 +150,7 @@ export const ChangeParamInput = () => {
     register,
     formState: { errors: formErrors },
     control,
+    setValue,
   } = useFormContext<ProposalFormActions>();
 
   const { prefix, index, onRemove } = useContext(ActionFormContext);
@@ -188,6 +190,16 @@ export const ChangeParamInput = () => {
     interfaceName: watchPlugin?.interfaceName,
     variableName: watchParam?.variableName,
   });
+
+  //Shadow register for type
+  useEffect(() => {
+    register(`${prefix}.type`);
+  }, []);
+
+  //Keep type updated with watchParam
+  useEffect(() => {
+    setValue(`${prefix}.type`, watchParam?.variableType ?? '');
+  }, [watchParam]);
 
   return (
     <MainCard

--- a/src/components/newProposal/actions/ChangeParamInput.tsx
+++ b/src/components/newProposal/actions/ChangeParamInput.tsx
@@ -160,7 +160,7 @@ export const ChangeParamInput = () => {
     error: variablesErrors,
     refetch: refetchVariables,
     variables,
-  } = useDaoVariables({});
+  } = useDaoVariables();
 
   const errors: ActionFormError<ProposalFormChangeParamData> =
     formErrors.actions ? formErrors.actions[index] : undefined;

--- a/src/components/newProposal/steps/Confirmation.tsx
+++ b/src/components/newProposal/steps/Confirmation.tsx
@@ -8,9 +8,7 @@
 
 import { useEffect, useState } from 'react';
 import { ProposalFormVotingSettings } from '@/src/components/newProposal/steps/Voting';
-import ProposalActions, {
-  ActionView,
-} from '@/src/components/proposal/ProposalActions';
+import ProposalActions from '@/src/components/proposal/ProposalActions';
 import { ProposalResources } from '@/src/components/proposal/ProposalResources';
 import CategoryList from '@/src/components/ui/CategoryList';
 import { HeaderCard } from '@/src/components/ui/HeaderCard';
@@ -44,11 +42,11 @@ import { ErrorWrapper } from '../../ui/ErrorWrapper';
  */
 const parseActionInputs = async (
   actions: ProposalFormActionData[]
-): Promise<ActionView[]> => {
-  const res: ActionView[] = [];
+): Promise<Action[]> => {
+  const res: Action[] = [];
   actions.forEach((action) => {
     const parsed = ACTIONS[action.name].parseInput(action as any);
-    if (parsed) res.push({ ...parsed, name: action.name });
+    if (parsed) res.push(parsed);
   });
 
   return res;

--- a/src/components/newProposal/steps/Confirmation.tsx
+++ b/src/components/newProposal/steps/Confirmation.tsx
@@ -8,7 +8,9 @@
 
 import { useEffect, useState } from 'react';
 import { ProposalFormVotingSettings } from '@/src/components/newProposal/steps/Voting';
-import ProposalActions from '@/src/components/proposal/ProposalActions';
+import ProposalActions, {
+  ActionView,
+} from '@/src/components/proposal/ProposalActions';
 import { ProposalResources } from '@/src/components/proposal/ProposalResources';
 import CategoryList from '@/src/components/ui/CategoryList';
 import { HeaderCard } from '@/src/components/ui/HeaderCard';
@@ -42,12 +44,12 @@ import { ErrorWrapper } from '../../ui/ErrorWrapper';
  */
 const parseActionInputs = async (
   actions: ProposalFormActionData[]
-): Promise<Action[]> => {
-  const res: Action[] = [];
-  const parsed = await Promise.all(
-    actions.map((action) => ACTIONS[action.name].parseInput(action as any))
-  );
-  parsed.forEach((action) => action && res.push(action));
+): Promise<ActionView[]> => {
+  const res: ActionView[] = [];
+  actions.forEach((action) => {
+    const parsed = ACTIONS[action.name].parseInput(action as any);
+    if (parsed) res.push({ ...parsed, name: action.name });
+  });
 
   return res;
 };

--- a/src/components/proposal/ProposalActions.tsx
+++ b/src/components/proposal/ProposalActions.tsx
@@ -18,18 +18,12 @@ import {
   MainCard,
   MainCardProps,
 } from '@/src/components/ui/MainCard';
-import { ACTIONS, ActionName, actionToName } from '@/src/lib/constants/actions';
+import { ACTIONS, actionToName } from '@/src/lib/constants/actions';
 import { Action } from '@plopmenz/diamond-governance-sdk';
-
-/** Extends the Action type to add an optional name property,
- * which can be used to overwrite the usual mapping of the action to its ActionName */
-export interface ActionView extends Action {
-  name?: ActionName;
-}
 
 export interface ProposalActionsProps
   extends Omit<MainCardProps, 'icon' | 'header'> {
-  actions: ActionView[] | undefined;
+  actions: Action[] | undefined;
   loading?: boolean;
 }
 
@@ -61,7 +55,7 @@ const ProposalActions = ({
       ) : (
         <Accordion type="single" collapsible className="space-y-2">
           {actions.map((action, i) => {
-            const actionName = action.name ?? actionToName(action);
+            const actionName = actionToName(action);
             if (!actionName)
               return (
                 <UnknownAction key={i} value={i.toString()} action={action} />

--- a/src/components/proposal/ProposalActions.tsx
+++ b/src/components/proposal/ProposalActions.tsx
@@ -18,12 +18,18 @@ import {
   MainCard,
   MainCardProps,
 } from '@/src/components/ui/MainCard';
-import { ACTIONS, actionToName } from '@/src/lib/constants/actions';
+import { ACTIONS, ActionName, actionToName } from '@/src/lib/constants/actions';
 import { Action } from '@plopmenz/diamond-governance-sdk';
+
+/** Extends the Action type to add an optional name property,
+ * which can be used to overwrite the usual mapping of the action to its ActionName */
+export interface ActionView extends Action {
+  name?: ActionName;
+}
 
 export interface ProposalActionsProps
   extends Omit<MainCardProps, 'icon' | 'header'> {
-  actions: Action[] | undefined;
+  actions: ActionView[] | undefined;
   loading?: boolean;
 }
 
@@ -55,7 +61,7 @@ const ProposalActions = ({
       ) : (
         <Accordion type="single" collapsible className="space-y-2">
           {actions.map((action, i) => {
-            const actionName = actionToName(action);
+            const actionName = action.name ?? actionToName(action);
             if (!actionName)
               return (
                 <UnknownAction key={i} value={i.toString()} action={action} />

--- a/src/components/proposal/ProposalVotes.tsx
+++ b/src/components/proposal/ProposalVotes.tsx
@@ -25,10 +25,12 @@ import {
 } from '@/src/components/ui/Dialog';
 import { DefaultMainCardHeader, MainCard } from '@/src/components/ui/MainCard';
 import { CanVote } from '@/src/hooks/useProposal';
-import { TOKENS } from '@/src/lib/constants/tokens';
 import { calcBigNumberPercentage, cn } from '@/src/lib/utils';
-import { toAbbreviatedTokenAmount } from '@/src/lib/utils/token';
-import { AddressVotes, Proposal } from '@plopmenz/diamond-governance-sdk';
+import {
+  AddressVotes,
+  Proposal,
+  ProposalStatus,
+} from '@plopmenz/diamond-governance-sdk';
 import { format } from 'date-fns';
 import { BigNumber } from 'ethers';
 import { HiChatBubbleLeftRight } from 'react-icons/hi2';
@@ -50,42 +52,36 @@ interface ProposalVotesProps {
  */
 const getCategories = (
   proposal: Proposal | null,
+  currentParticipation: number,
   totalVotingWeight: BigNumber
 ): Category[] => {
   if (!proposal) return [];
-
-  const currentParticipation = calcBigNumberPercentage(
-    proposal.data.tally.yes
-      .add(proposal.data.tally.no)
-      .add(proposal.data.tally.abstain),
-    totalVotingWeight
-  );
 
   const uniqueVoters = proposal.data.voterList.reduce(
     (acc, vote) => acc.add(vote),
     new Set<string>()
   ).size;
 
+  const minParticipation = calcBigNumberPercentage(
+    proposal.data.parameters.minParticipationThresholdPower,
+    totalVotingWeight
+  );
+
   return [
     {
       title: 'Decision rules',
       items: [
         {
-          label: 'Support threshold',
-          value: `${
+          label: 'Approval threshold',
+          value: `≥ ${
             // Converts the supportThreshold from integer to percentage (e.g. 500000000 -> 50%)
             // Necessary because this number has to be stored as an integer on the blockchain, so cannot have decimals
             proposal.data.parameters.supportThreshold / 10 ** 4
-          }%`,
+          }% Yes`,
         },
         {
           label: 'Minimum participation',
-          value: `${toAbbreviatedTokenAmount({
-            value: proposal.data.parameters.minParticipationThresholdPower,
-            tokenDecimals: TOKENS.rep.decimals,
-            displayDecimals: 0,
-          })} 
-          ${TOKENS.rep.symbol}`,
+          value: `≥ ${minParticipation}%`,
         },
       ],
     },
@@ -93,7 +89,7 @@ const getCategories = (
       title: 'Voting activity',
       items: [
         {
-          label: 'Current participation',
+          label: 'Current participation / quorum',
           value: `${currentParticipation}%`,
         },
         {
@@ -129,6 +125,15 @@ const ProposalVotes = ({
   className,
   ...props
 }: ProposalVotesProps) => {
+  const currentParticipation = proposal
+    ? calcBigNumberPercentage(
+        proposal.data.tally.yes
+          .add(proposal.data.tally.no)
+          .add(proposal.data.tally.abstain),
+        props.totalVotingWeight
+      )
+    : 0;
+
   return (
     <MainCard
       loading={loading}
@@ -144,26 +149,40 @@ const ProposalVotes = ({
         />
       }
       aside={
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button variant="subtle" label="View details" />
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Voting details</DialogTitle>
-              <DialogDescription asChild>
-                <CategoryList
-                  categories={getCategories(proposal, props.totalVotingWeight)}
-                />
-              </DialogDescription>
-            </DialogHeader>
-            <DialogClose asChild>
-              <div className="flex items-end justify-end">
-                <Button variant="subtle" label="Close" className="self-end" />
-              </div>
-            </DialogClose>
-          </DialogContent>
-        </Dialog>
+        <div className="flex items-center gap-x-2">
+          <p
+            className={cn(
+              'text-highlight-foreground/80',
+              proposal?.status === ProposalStatus.Active && 'ml-6'
+            )}
+          >
+            Quorum: {currentParticipation}%
+          </p>
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="subtle" label="View details" />
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Voting details</DialogTitle>
+                <DialogDescription asChild>
+                  <CategoryList
+                    categories={getCategories(
+                      proposal,
+                      currentParticipation,
+                      props.totalVotingWeight
+                    )}
+                  />
+                </DialogDescription>
+              </DialogHeader>
+              <DialogClose asChild>
+                <div className="flex items-end justify-end">
+                  <Button variant="subtle" label="Close" className="self-end" />
+                </div>
+              </DialogClose>
+            </DialogContent>
+          </Dialog>
+        </div>
       }
     >
       {proposal && (

--- a/src/components/proposal/VotesContent.tsx
+++ b/src/components/proposal/VotesContent.tsx
@@ -254,10 +254,16 @@ const VotesContentOption = ({
   const voteValueString = VoteOption[voteOption];
 
   const voteValueLower = voteValueString.toLowerCase() as VoteOptionStringLower;
-  const voteTally = proposal.data.tally[voteValueLower];
   const filteredVotes = votes.filter(
     (vote) => vote.votes[0].option === voteOption
   );
+  const voteTally =
+    voteOption === VoteOption.Abstain
+      ? filteredVotes.reduce(
+          (acc, vote) => acc.add(vote.votes[0].amount),
+          BigNumber.from(0)
+        )
+      : proposal.data.tally[voteValueLower];
   const percentage = calcBigNumberPercentage(voteTally, totalVotingWeight);
 
   return (

--- a/src/components/proposal/actions/ChangeParamAction.tsx
+++ b/src/components/proposal/actions/ChangeParamAction.tsx
@@ -14,10 +14,9 @@ import { Card } from '../../ui/Card';
 import ActionWrapper from './ActionWrapper';
 
 export interface ProposalChangeParamAction extends Action {
+  // param name and value type depend on the plugin and parameter being changed
   params: {
-    _plugin: string;
-    _param: string;
-    _value: string;
+    [key: string]: any;
   };
 }
 interface ChangeParamActionProps extends AccordionItemProps {
@@ -39,18 +38,22 @@ export const ChangeParamAction = ({
         <div className="grid grid-cols-2 gap-2">
           <Card variant="outline" size="sm">
             <p className="text-xs text-popover-foreground/80">Plugin</p>
-            <p className="font-medium">{action.params._plugin}</p>
+            <p className="font-medium">{action.interface}</p>
           </Card>
           <Card variant="outline" size="sm">
             <p className="text-xs text-popover-foreground/80">Parameter</p>
-            <p className="font-medium">{action.params._param}</p>
+            {/* First splits the method name on '(' to remove the parameters
+                Then slices the remaining string to remove the 'set' in front of the variable name */}
+            <p className="font-medium">
+              {action.method.split('(')[0].slice(3)}
+            </p>
           </Card>
         </div>
         <Card variant="outline" size="sm">
-          <p className="text-xs text-popover-foreground/80">
-            New parameter value
+          <p className="text-xs text-popover-foreground/80">New value</p>
+          <p className="font-medium">
+            {Object.values(action.params)[0].toString()}
           </p>
-          <p className="font-medium">{action.params._value}</p>
         </Card>
       </div>
     </ActionWrapper>

--- a/src/components/ui/CategoryList.tsx
+++ b/src/components/ui/CategoryList.tsx
@@ -65,7 +65,9 @@ const CategoryList = React.forwardRef<HTMLDivElement, CategoryListProps>(
                 key={item.label}
                 className="flex flex-row justify-between gap-x-2"
               >
-                <p className="text-popover-foreground/80">{item.label}</p>
+                <p className="text-left text-popover-foreground/80">
+                  {item.label}
+                </p>
                 <p className="text-primary-highlight">{item.value}</p>
               </div>
             ))}

--- a/src/hooks/useDaoVariables.ts
+++ b/src/hooks/useDaoVariables.ts
@@ -19,6 +19,8 @@ export type UseDaoVariablesData = {
   loading: boolean;
   error: string | null;
   variables: InterfaceVariables[] | null;
+  /** Set of interface+method identifiers for all fetched variables */
+  variableMap: Set<string> | null;
   values: Record<string, Record<string, FetchVariableResult>> | null;
   refetch: () => void;
 };
@@ -57,6 +59,7 @@ export const useDaoVariables = ({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [variables, setVariables] = useState<InterfaceVariables[] | null>(null);
+  const [variableMap, setVariableMap] = useState<Set<string> | null>(null);
   const [values, setValues] = useState<Record<
     string,
     Record<string, FetchVariableResult>
@@ -127,10 +130,24 @@ export const useDaoVariables = ({
     refetch();
   }, [client]);
 
+  useEffect(() => {
+    if (!variables) return;
+    const _variableMap = new Set<string>();
+    variables.forEach((v) => {
+      v.variables.forEach((vv) => {
+        _variableMap.add(
+          `${v.interfaceName}.set${vv.variableName}(${vv.variableType})`
+        );
+      });
+    });
+    setVariableMap(_variableMap);
+  }, [variables]);
+
   return {
     loading,
     error,
     variables,
+    variableMap,
     values,
     refetch,
   };

--- a/src/hooks/useProposal.ts
+++ b/src/hooks/useProposal.ts
@@ -13,12 +13,13 @@ import { ProposalMintAction } from '@/src/components/proposal/actions/MintAction
 import { ProposalWithdrawAction } from '@/src/components/proposal/actions/WithdrawAction';
 import { useDiamondSDKContext } from '@/src/context/DiamondGovernanceSDK';
 import { useVotingPower } from '@/src/hooks/useVotingPower';
-import { ACTIONS } from '@/src/lib/constants/actions';
+import { ACTIONS, getIdentifier } from '@/src/lib/constants/actions';
 import {
   AddressVotes,
   DiamondGovernanceClient,
   IPartialVotingFacet,
   IPartialVotingProposalFacet,
+  InterfaceVariables,
   Proposal,
   ProposalStatus,
   VoteOption,
@@ -201,6 +202,26 @@ export const dummyVotes: AddressVotes[] = [
     ],
   },
 ];
+
+/**
+ * Parses a proposal, returning the same proposal with the actions parsed.
+ * @param proposal The proposal to parse
+ */
+export const parseProposal = (
+  proposal: Proposal,
+  variableMap: Set<string>
+): Proposal => {
+  proposal.actions = proposal.actions.map((action) => {
+    if (variableMap.has(getIdentifier(action)))
+      return {
+        ...action,
+        interface: 'DAO',
+        method: 'ChangeParam',
+      };
+    return action;
+  });
+  return proposal;
+};
 
 export const useProposal = ({
   id,

--- a/src/hooks/useProposal.ts
+++ b/src/hooks/useProposal.ts
@@ -24,6 +24,7 @@ import {
   VoteOption,
 } from '@plopmenz/diamond-governance-sdk';
 import { BigNumber, ContractTransaction } from 'ethers';
+import { useAccount } from 'wagmi';
 
 export type CanVote = {
   Yes: boolean;
@@ -204,7 +205,17 @@ export const useProposal = ({
   address,
   useDummyData = false,
 }: UseProposalProps): UseProposalData => {
+  /*
+    The anonProposal (anonymous proposal) is shown when no wallet is connected
+    The regular proposal is shown when a wallet is connected
+    This was necessary because there was an issue where if the same state
+    variable was used for both, somehow the signer in the proposal would stick
+    to the zero address, even after a signer of connected wallet becomes available and 
+    the proposal was refreshed. Possibly due to delayed state updates
+  */
   const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [anonProposal, setAnonProposal] = useState<Proposal | null>(null);
+
   const [canExecute, setCanExecute] = useState<boolean>(false);
   const [canVote, setCanVote] = useState<CanVote>({
     Yes: false,
@@ -215,12 +226,21 @@ export const useProposal = ({
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const { anonClient, client } = useDiamondSDKContext();
+  const { isConnected } = useAccount();
   const { proposalVotingPower } = useVotingPower({
     address,
     proposal: proposal ?? undefined,
   });
 
-  const fetchProposal = async (client?: DiamondGovernanceClient) => {
+  /**
+   * Fetch a proposal from the SDK
+   * @param client Diamond SDK client
+   * @param anon Whether or not an anonymous client is being used
+   */
+  const fetchProposal = async (
+    client?: DiamondGovernanceClient,
+    anon = false
+  ) => {
     if (!client) return;
     if (!id) {
       setError('Proposal not found');
@@ -232,12 +252,15 @@ export const useProposal = ({
       const daoProposal: Proposal = await client.sugar.GetProposal(+id);
 
       if (daoProposal) {
-        setProposal(daoProposal);
+        if (anon) setAnonProposal(daoProposal);
+        else setProposal(daoProposal);
         setError(null);
         setLoading(false);
         fetchVotes(daoProposal);
-        checkCanExecute(daoProposal);
-        checkCanVote(daoProposal);
+        if (!anon) {
+          checkCanExecute(daoProposal);
+          checkCanVote(daoProposal);
+        }
       } else {
         setError('Proposal not found');
         setLoading(false);
@@ -272,7 +295,7 @@ export const useProposal = ({
 
   useEffect(() => {
     if (useDummyData) return setDummyData();
-    fetchProposal(client ?? anonClient);
+    fetchProposal(client ?? anonClient, !client);
   }, [client, anonClient, id]);
 
   const checkCanExecute = async (proposal: Proposal) => {
@@ -312,7 +335,7 @@ export const useProposal = ({
   return {
     loading,
     error,
-    proposal,
+    proposal: isConnected ? proposal : anonProposal,
     canExecute,
     canVote,
     votes,

--- a/src/hooks/useProposal.ts
+++ b/src/hooks/useProposal.ts
@@ -19,7 +19,6 @@ import {
   DiamondGovernanceClient,
   IPartialVotingFacet,
   IPartialVotingProposalFacet,
-  InterfaceVariables,
   Proposal,
   ProposalStatus,
   VoteOption,
@@ -127,15 +126,12 @@ export const dummyMergeAction: ProposalMergeAction = {
 
 /**
  * Dummy mint tokens action
- * @note Not yet correct
  */
 export const dummyChangeParamsAction: ProposalChangeParamAction = {
-  method: ACTIONS.change_param.method,
-  interface: ACTIONS.change_param.interface,
+  method: 'setMaxSingleWalletPower(uint32)',
+  interface: 'IPartialVotingProposalFacet',
   params: {
-    _plugin: 'TokenVoting',
-    _param: 'supportThreshold',
-    _value: '1',
+    _maxSingleWalletPower: 100000,
   },
 };
 

--- a/src/hooks/useProposal.ts
+++ b/src/hooks/useProposal.ts
@@ -13,7 +13,7 @@ import { ProposalMintAction } from '@/src/components/proposal/actions/MintAction
 import { ProposalWithdrawAction } from '@/src/components/proposal/actions/WithdrawAction';
 import { useDiamondSDKContext } from '@/src/context/DiamondGovernanceSDK';
 import { useVotingPower } from '@/src/hooks/useVotingPower';
-import { ACTIONS, getIdentifier } from '@/src/lib/constants/actions';
+import { ACTIONS } from '@/src/lib/constants/actions';
 import {
   AddressVotes,
   DiamondGovernanceClient,
@@ -199,26 +199,6 @@ export const dummyVotes: AddressVotes[] = [
   },
 ];
 
-/**
- * Parses a proposal, returning the same proposal with the actions parsed.
- * @param proposal The proposal to parse
- */
-export const parseProposal = (
-  proposal: Proposal,
-  variableMap: Set<string>
-): Proposal => {
-  proposal.actions = proposal.actions.map((action) => {
-    if (variableMap.has(getIdentifier(action)))
-      return {
-        ...action,
-        interface: 'DAO',
-        method: 'ChangeParam',
-      };
-    return action;
-  });
-  return proposal;
-};
-
 export const useProposal = ({
   id,
   address,
@@ -282,7 +262,7 @@ export const useProposal = ({
     }
   };
 
-  //** Set dummy data for development without querying Aragon API */
+  //** Set dummy data for development without querying SDK */
   const setDummyData = () => {
     setLoading(false);
     setError(null);
@@ -306,12 +286,9 @@ export const useProposal = ({
   };
 
   const checkCanVote = async (proposal: Proposal) => {
-    // Check if proposal.id === canVoteId to avoid unnecessary refetching of the canVote data
     if (!proposalVotingPower) return;
 
     try {
-      console.log('fetching CanVote', proposalVotingPower);
-
       const values = [VoteOption.Abstain, VoteOption.Yes, VoteOption.No];
       const canVoteData = await Promise.all(
         values.map((vote) => proposal.CanVote(vote, proposalVotingPower))

--- a/src/hooks/useProposals.ts
+++ b/src/hooks/useProposals.ts
@@ -82,7 +82,7 @@ export const useProposals = (props?: UseProposalsProps): UseProposalsData => {
       const daoProposals: Proposal[] | null = await client.sugar.GetProposals(
         status ? [status] : undefined,
         sorting,
-        order === undefined ? SortingOrder.Desc : order,
+        order,
         undefined,
         limit
       );

--- a/src/lib/constants/actions.tsx
+++ b/src/lib/constants/actions.tsx
@@ -238,7 +238,6 @@ export const ACTIONS: Actions = {
     view: ChangeParamAction,
     input: ChangeParamInput,
     emptyInputData: emptyChangeParamData,
-    maxPerProposal: 1,
     parseInput: (input) => {
       try {
         let parsedValue: string | number | boolean | BigNumber = input.value;

--- a/src/lib/constants/actions.tsx
+++ b/src/lib/constants/actions.tsx
@@ -376,7 +376,7 @@ export const getIdentifier = (action: Action | ActionData<any, any>) =>
  * const actionName = actionNames['IERC20MultiMinterFacet.multimint(address[],uint256[])']
  * // actionName === 'mint_tokens'
  */
-const actionNames: { [identifier: string]: ActionName } = {};
+export const actionNames: { [identifier: string]: ActionName } = {};
 Object.entries(ACTIONS).forEach(([name, action]) => {
   if (typeof action.method === 'string')
     actionNames[getIdentifier({ ...action, method: action.method })] =

--- a/src/lib/constants/actions.tsx
+++ b/src/lib/constants/actions.tsx
@@ -377,6 +377,9 @@ export const getIdentifier = (action: Action | ActionData<any, any>) =>
  * // actionName === 'mint_tokens'
  */
 export const actionNames: { [identifier: string]: ActionName } = {};
+// Developer's note: the actonNames object is expanded upon with the identifiers for all possible
+// change_param action interfaces and methods in DiamondGovernanceSDK.tsx, after fetching the
+// list of all possible variables to change in the DAO from the SDK.
 Object.entries(ACTIONS).forEach(([name, action]) => {
   if (typeof action.method === 'string')
     actionNames[getIdentifier({ ...action, method: action.method })] =

--- a/src/lib/constants/actions.tsx
+++ b/src/lib/constants/actions.tsx
@@ -46,6 +46,7 @@ import WithdrawAction, {
   ProposalWithdrawAction,
 } from '@/src/components/proposal/actions/WithdrawAction';
 import { TOKENS } from '@/src/lib/constants/tokens';
+import { lowerCaseFirst } from '@/src/lib/utils';
 import { parseTokenAmount } from '@/src/lib/utils/token';
 import { TokenType } from '@aragon/sdk-client';
 import { Action } from '@plopmenz/diamond-governance-sdk';
@@ -227,8 +228,10 @@ export const ACTIONS: Actions = {
     },
   },
   change_param: {
-    method: 'changeParameter(string,uint256)',
-    interface: 'IChangeParameter',
+    // The method and interface for this action are dynamically generated in the parseInput function
+    // The actions being fetched are first parsed to make sure all change param actions have this method and interface
+    method: 'ChangeParam',
+    interface: 'DAO',
     label: 'Change param',
     longLabel: 'Change plugin parameters',
     icon: HiOutlineCog,
@@ -237,13 +240,14 @@ export const ACTIONS: Actions = {
     emptyInputData: emptyChangeParamData,
     maxPerProposal: 1,
     parseInput: (input) => {
+      console.log(input);
+      const parsedValue = input.value;
+
       return {
-        method: ACTIONS.change_param.method as string,
-        interface: ACTIONS.change_param.interface,
+        method: `set${input.parameter}(${input.type})`,
+        interface: input.plugin,
         params: {
-          _plugin: input.plugin,
-          _param: input.parameter,
-          _value: input.value,
+          [`_${lowerCaseFirst(input.parameter)}`]: parsedValue,
         },
       };
     },
@@ -347,8 +351,8 @@ type ActionData<TAction, TFormData, TMethod extends string | void = void> = {
  * const identifier = getIdentifier(action);
  * console.log(identifier); // "IERC20MultiMinterFacet.multimint(address[],uint256[])"
  */
-const getIdentifier = (action: Action | ActionData<any, any>) =>
-  `${action.interface}.${typeof action.method}`;
+export const getIdentifier = (action: Action | ActionData<any, any>) =>
+  `${action.interface}.${action.method}`;
 
 /**
  * Object that maps an action identifier to a more readable name as defined in the ACTIONS object.

--- a/src/lib/constants/actions.tsx
+++ b/src/lib/constants/actions.tsx
@@ -240,16 +240,33 @@ export const ACTIONS: Actions = {
     emptyInputData: emptyChangeParamData,
     maxPerProposal: 1,
     parseInput: (input) => {
-      console.log(input);
-      const parsedValue = input.value;
+      try {
+        let parsedValue: string | number | boolean | BigNumber = input.value;
+        if (
+          input.type === 'uint8' ||
+          input.type === 'uint16' ||
+          input.type === 'uint32'
+        )
+          parsedValue = Number.parseInt(input.value);
+        else if (input.type === 'boolean' && input.value === 'false')
+          parsedValue = false;
+        else if (input.type === 'boolean' && input.value === 'true')
+          parsedValue = true;
+        else if (input.type === 'string' || input.type === 'address')
+          parsedValue = input.value;
+        else parsedValue = BigNumber.from(input.value);
 
-      return {
-        method: `set${input.parameter}(${input.type})`,
-        interface: input.plugin,
-        params: {
-          [`_${lowerCaseFirst(input.parameter)}`]: parsedValue,
-        },
-      };
+        return {
+          method: `set${input.parameter}(${input.type})`,
+          interface: input.plugin,
+          params: {
+            [`_${lowerCaseFirst(input.parameter)}`]: parsedValue,
+          },
+        };
+      } catch (e) {
+        console.log(e);
+        return null;
+      }
     },
   },
   // Add new proposal actions here:

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { anyNullOrUndefined, cn } from '@/src/lib/utils';
+import { anyNullOrUndefined, cn, lowerCaseFirst } from '@/src/lib/utils';
 
 // These are very simplistic tests, mostly meant as example tests.
 
@@ -33,4 +33,10 @@ test('anyNullOrUndefined works for null and undefined', () => {
 
 test('anyNullOrUndefined does not trigger for falsy values', () => {
   expect(anyNullOrUndefined(0, '', 'null', 'undefined')).toBeFalsy;
+});
+
+test('lowerCaseFirst works as intended', () => {
+  expect(lowerCaseFirst('Test')).toBe('test');
+  expect(lowerCaseFirst('test')).toBe('test');
+  expect(lowerCaseFirst('')).toBe('');
 });

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -135,3 +135,12 @@ export function assertUnreachable(x: never): never {
 export function IsEmptyOrOnlyWhitespace(x: string): boolean {
   return x.trim() === '';
 }
+
+/**
+ * Lowercases the first letter of a string
+ * @param x String to lowercase the first letter of
+ * @returns The string with the first letter lowercased
+ */
+export function lowerCaseFirst(x: string): string {
+  return x.charAt(0).toLowerCase() + x.slice(1);
+}


### PR DESCRIPTION
# Description

Adds support for parameter actions beyond just the input component.
The identifiers for the different change_param actions are added to the `actionNames` object dynamically by fetching the variables from the SDK as soon as it becomes available.

Also made a change where the abstain percentage on the view-proposal page is calculated based on the actual votes instead of using the tally, because the tally includes the overflow of voting power from other votes. 
Current participation (quorum) is now displayed more clearly, and changed some naming/text in the Voting details dialog.
