### PR TITLE
SECOIN Verification Reward + Mining Reward Estimation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aragon/sdk-client": "^1.4.0",
-        "@plopmenz/diamond-governance-sdk": "^0.2.0",
+        "@plopmenz/diamond-governance-sdk": "^0.2.1",
         "@radix-ui/react-accordion": "^1.1.1",
         "@radix-ui/react-alert-dialog": "^1.0.3",
         "@radix-ui/react-collapsible": "^1.0.2",
@@ -5883,9 +5883,9 @@
       "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@plopmenz/diamond-governance-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@plopmenz/diamond-governance-sdk/-/diamond-governance-sdk-0.2.0.tgz",
-      "integrity": "sha512-75oBtKmO0do+Zdv75LkYn8LEgECk17730kPUShyBqgV5CJhPOWFu+EjymNWe+vqoRO9PZ8bT9A7EJHnJoP7kfw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@plopmenz/diamond-governance-sdk/-/diamond-governance-sdk-0.2.1.tgz",
+      "integrity": "sha512-jJpPvYAGTljhV0L4fNJtimml9n/ow21n9GXQpIls9xYPPKM1UZgzp+aduaMwOIa7rA1Waf1zoCrcDy0G9ORJDA==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@aragon/sdk-client": "^1.4.0",
-    "@plopmenz/diamond-governance-sdk": "^0.2.0",
+    "@plopmenz/diamond-governance-sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-alert-dialog": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.2",

--- a/src/components/verification/OneTimeRewardCard.stories.tsx
+++ b/src/components/verification/OneTimeRewardCard.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    reward: BigNumber.from('0x4563918244F40000'),
+    reward: [BigNumber.from('0x4563918244F40000'), BigNumber.from(5).pow(18)],
     claimReward() {
       return Promise.resolve({} as any);
     },

--- a/src/components/verification/OneTimeRewardCard.tsx
+++ b/src/components/verification/OneTimeRewardCard.tsx
@@ -16,6 +16,8 @@ import { TOKENS } from '@/src/lib/constants/tokens';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { HiGift } from 'react-icons/hi2';
 
+import { Label } from '../ui/Label';
+
 /**
  * @returns A card that allows the users to claim their reward for verifying
  */
@@ -24,7 +26,7 @@ const OneTimeRewardCard = ({
   claimReward,
   refetch,
 }: {
-  reward: BigNumber | null;
+  reward: [BigNumber, BigNumber];
   claimReward: () => Promise<ContractTransaction>;
   refetch: () => void;
 }) => {
@@ -54,17 +56,25 @@ const OneTimeRewardCard = ({
         You are eligible to claim a onetime verification reward for verifying
         your wallet with one or more providers.
       </p>
-      <Card variant="outline" className="flex flex-row items-center gap-x-2">
-        Claimable amount:
-        <strong>
+      <Label>Claimable amount</Label>
+      <div className="flex items-center gap-2">
+        <Card variant="outline" className="flex flex-row items-center gap-x-2">
           <TokenAmount
-            amount={reward}
+            amount={reward[0]}
             tokenDecimals={TOKENS.rep.decimals}
             symbol={TOKENS.rep.symbol}
             displayDecimals={0}
           />
-        </strong>
-      </Card>
+        </Card>
+        <Card variant="outline" className="flex flex-row items-center gap-x-2">
+          <TokenAmount
+            amount={reward[1]}
+            tokenDecimals={TOKENS.secoin.decimals}
+            symbol={TOKENS.secoin.symbol}
+            displayDecimals={0}
+          />
+        </Card>
+      </div>
       <Button
         label="Claim reward"
         onClick={handleClaimReward}

--- a/src/context/DiamondGovernanceSDK.tsx
+++ b/src/context/DiamondGovernanceSDK.tsx
@@ -103,10 +103,10 @@ export function DiamondSDKWrapper({ children }: any): JSX.Element {
 
     const getSecoinAddress = async () => {
       if (!anonClient) return;
-      const IChangeableTokenContract =
-        await anonClient.pure.IChangeableTokenContract();
+      const IMonetaryTokenFacetContract =
+        await anonClient.pure.IMonetaryTokenFacet();
       const monetaryTokenContractAddress =
-        await IChangeableTokenContract.getTokenContractAddress();
+        await IMonetaryTokenFacetContract.getTokenContractAddress();
       setSecoinAddress(monetaryTokenContractAddress);
     };
 

--- a/src/hooks/useSearchSECO.ts
+++ b/src/hooks/useSearchSECO.ts
@@ -565,14 +565,6 @@ export const useSearchSECO = (
 
     const { proof } = json;
 
-    console.log(
-      address,
-      hashCount.toNumber(),
-      nonce.toNumber(),
-      repFrac.toNumber(),
-      proof.sig
-    );
-
     return await rewarding.rewardMinerForHashes(
       address,
       hashCount,

--- a/src/hooks/useVerification.ts
+++ b/src/hooks/useVerification.ts
@@ -55,7 +55,9 @@ export const useVerification = () => {
   const [verificationHistory, setVerificationHistory] = useState<
     VerificationHistory[]
   >([]);
-  const [reward, setReward] = useState<BigNumber | null>(null);
+
+  // REP & COIN reward for verifying
+  const [reward, setReward] = useState<[BigNumber, BigNumber] | null>(null);
 
   const { client } = useDiamondSDKContext();
   const { address } = useAccount();

--- a/src/lib/constants/DaoVariablesMetadata.ts
+++ b/src/lib/constants/DaoVariablesMetadata.ts
@@ -110,7 +110,7 @@ export const DAO_VARIABLES_METADATA: DaoVariablesMetadata = {
         'The percentage of the mining reward pool that is paid out when the HashDevaluationFactor is reached.',
     },
   },
-  IChangeableTokenContract: {
+  IMonetaryTokenFacet: {
     TokenContractAddress: {
       description: `Address of the ERC20 contract of the monetary token of the DAO (${TOKENS.secoin.symbol}).`,
     },

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -11,7 +11,7 @@ export const CONFIG = {
     'https://securesecodao-api.herokuapp.com/verification_api',
   SEARCHSECO_API_URL: 'https://searchseco-api.herokuapp.com/api',
   PR_MERGER_API_URL: 'https://securesecodao-pr-merger.herokuapp.com',
-  DIAMOND_ADDRESS: '0xa8326b1c6b2595e51e59Ea98A3995866D7b3E299',
+  DIAMOND_ADDRESS: '0x3f2922e8c72ed5D1a383B04FC60F232041C1bb06',
   PREFERRED_NETWORK_ID: 80001,
 } as const;
 

--- a/src/pages/Mining.tsx
+++ b/src/pages/Mining.tsx
@@ -120,9 +120,6 @@ export const Mining = () => {
       );
       setReputation(repEst);
       setMonetary(monEst);
-
-      console.log('repEst', repEst.toString());
-      console.log('monEst', monEst.toString());
     }, 500);
 
     return () => clearTimeout(updateEstimate);

--- a/src/pages/Verification.tsx
+++ b/src/pages/Verification.tsx
@@ -276,13 +276,15 @@ const Verification = () => {
         </MainCard>
 
         <div className="col-span-full flex flex-col gap-y-6 lg:col-span-3">
-          {isConnected && reward !== null && reward.gt(0) && (
-            <OneTimeRewardCard
-              reward={reward}
-              claimReward={claimReward}
-              refetch={refetch}
-            />
-          )}
+          {isConnected &&
+            reward !== null &&
+            (reward[0].gt(0) || reward[1].gt(1)) && (
+              <OneTimeRewardCard
+                reward={reward}
+                claimReward={claimReward}
+                refetch={refetch}
+              />
+            )}
           <MainCard
             loading={false}
             icon={HiOutlineClock}


### PR DESCRIPTION
# Type of change

Fix

#### Does it contain breaking changes?

No

# Description

The user can now see the total amount of claimable hashes.
The nonce is now calculated client-sided.
SECOIN is now also claimable after verifying, using the same button as before.
On the mining page, the reward split is estimated live via a smart contract call (props to @djeelun )