### PR TITLE
Add diamond dashboard header + conditional diamond address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dao-webapp",
-  "version": "0.3.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dao-webapp",
-      "version": "0.3.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@aragon/sdk-client": "^1.4.0",

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -300,10 +300,11 @@ export const NavItemCollectionContent = ({
       <div className="grid h-full w-full grid-cols-2 divide-x divide-popover-foreground/10 bg-popover-foreground/5">
         {item.externalLinks &&
           item.externalLinks.map((item) => (
-            // Note: use a instead? (for external links)
-            <NavLink
+            <a
               key={item.label}
-              to={item.url}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
               className="flex items-center justify-center gap-x-2.5 p-3 font-semibold hover:bg-popover-foreground/20 ring-ring rounded-md focus:outline-none focus:ring-2"
             >
               <item.icon
@@ -311,7 +312,7 @@ export const NavItemCollectionContent = ({
                 aria-hidden="true"
               />
               {item.label}
-            </NavLink>
+            </a>
           ))}
       </div>
     </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -120,7 +120,11 @@ const navItems: NavItemData[] = [
         url: 'https://secureseco.org/',
         icon: HiOutlineGlobeAlt,
       },
-      { label: 'Discord', url: DAO_METADATA.discord, icon: FaDiscord },
+      {
+        label: 'Discord',
+        url: DAO_METADATA.links.discord.url,
+        icon: FaDiscord,
+      },
     ],
   },
 ];

--- a/src/components/newProposal/steps/Actions.tsx
+++ b/src/components/newProposal/steps/Actions.tsx
@@ -93,13 +93,16 @@ export const Actions = () => {
 
           throw error;
         }
-      }
+      } else return action;
     });
 
     Promise.all(actionPromises)
-      .then(() => {
+      .then((mappedActions) => {
         // If everything went OK, go to next step
-        setDataStep3(data);
+        setDataStep3({
+          ...data,
+          actions: mappedActions,
+        });
         setStep(4);
       })
       .catch((error) => {

--- a/src/components/proposal/ProposalResources.tsx
+++ b/src/components/proposal/ProposalResources.tsx
@@ -72,7 +72,7 @@ export const ProposalResources = ({
               <Card size="sm" variant="light">
                 <a
                   href={sanitizeHref(resource.url)}
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   target="_blank"
                   className="flex flex-row items-center gap-x-2 font-medium text-primary transition-colors duration-200 hover:text-primary/80"
                 >

--- a/src/components/proposal/actions/MergeAction.tsx
+++ b/src/components/proposal/actions/MergeAction.tsx
@@ -60,7 +60,7 @@ const MergeAction = ({ action, ...props }: MergeActionProps) => {
               className="w-fit flex flex-row items-center gap-x-2 text-primary-highlight transition-colors duration-200 hover:text-primary-highlight/80"
               href={`https://github.com/${action.params._owner}/${action.params._repo}/pull/${action.params._pull_number}`}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               View on GitHub
               <HiArrowTopRightOnSquare className="h-4 w-4 shrink-0" />

--- a/src/components/proposal/actions/MergeAction.tsx
+++ b/src/components/proposal/actions/MergeAction.tsx
@@ -73,6 +73,7 @@ const MergeAction = ({ action, ...props }: MergeActionProps) => {
             <Address
               className="font-medium"
               address={action.params._sha}
+              copyTooltip="Copy commit hash"
               showCopy
             />
           </Card>

--- a/src/components/ui/Address.tsx
+++ b/src/components/ui/Address.tsx
@@ -45,6 +45,7 @@ type AddressProps = {
   replaceYou?: boolean;
   jazziconSize?: keyof typeof jazziconVariants | number;
   className?: string;
+  copyTooltip?: string;
 };
 
 /**
@@ -69,6 +70,7 @@ export const Address: React.FC<AddressProps> = ({
   showCopy = false,
   replaceYou = false,
   jazziconSize = 'none',
+  copyTooltip = 'Copy address',
   className,
 }) => {
   const [status, setStatus] = useState<'idle' | 'copied'>('idle');
@@ -124,7 +126,13 @@ export const Address: React.FC<AddressProps> = ({
             )}
           </TooltipTrigger>
           <TooltipContent>
-            {hasLink ? <p>Open in block explorer</p> : <p>{address}</p>}
+            {hasLink ? (
+              <p>Open in block explorer</p>
+            ) : (
+              <p>
+                {address.length > 50 ? truncateMiddle(address, 50) : address}
+              </p>
+            )}
           </TooltipContent>
         </Tooltip>
 
@@ -143,7 +151,7 @@ export const Address: React.FC<AddressProps> = ({
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>Copy address</p>
+              <p>{copyTooltip}</p>
             </TooltipContent>
           </Tooltip>
         )}

--- a/src/components/ui/Address.tsx
+++ b/src/components/ui/Address.tsx
@@ -51,12 +51,13 @@ type AddressProps = {
 /**
  * A component for displaying Ethereum addresses, optionally with a link to Etherscan and a copy-to-clipboard button.
  * @param props - Props for the `Address` component.
- * @param props.address - The Ethereum address to display.
- * @param props.maxLength - The maximum length of the displayed address. If the address is longer than this, it will be truncated in the middle with an ellipsis. A negative value means no truncation.
- * @param props.hasLink - Whether the displayed address should be linked to its corresponding page on Etherscan.
- * @param props.showCopy - Whether to display a copy-to-clipboard button next to the address.
- * @param props.jazziconSize - The size of the Jazzicon to display next to the address (0 to show no Jazzicon)
- * @param [props.replaceYou=true] - Whether to replace the user's own Ethereum address with "you" in the displayed text.
+ * @param props.length - The length of the displayed address. Can be one of `sm`, `md`, `lg`, `full`, or a number. Defaults to `md`.
+ * @param props.hasLink - Whether to display a link to block explorer. Defaults to `false`.
+ * @param props.showCopy - Whether to display a copy-to-clipboard button. Defaults to `false`.
+ * @param props.replaceYou - Whether to replace the given with the string "you" if connected wallet is equal to given address. Defaults to `false`.
+ * @param props.jazziconSize - The size of the Jazzicon. Can be one of `none`, `sm`, `md`, `lg`, or a number. Defaults to `none`.
+ * @param props.copyTooltip - The tooltip text for the copy-to-clipboard button. Defaults to "Copy address".
+ * @param props.className - Class names to pass to the root div of this component.
  * @returns - A React element representing the `Address` component.
  * @remarks
  * This component uses the `useAccount` hook from the `wagmi` package to check the current user's Ethereum address.

--- a/src/components/verification/StampCard.tsx
+++ b/src/components/verification/StampCard.tsx
@@ -156,7 +156,7 @@ const StampCard = ({
             <a
               href={stampInfo.url}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="mx-1 rounded-sm text-primary-highlight outline-ring transition-colors duration-200 hover:text-primary-highlight/80"
             >
               {stampInfo.url}

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -304,7 +304,7 @@ toast.contractTransaction = async (
         <a
           href={`${explorerURL}/tx/${transaction.hash}`}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="flex flex-row items-center gap-x-1 text-xs text-primary"
         >
           View on block explorer

--- a/src/lib/constants/chains.ts
+++ b/src/lib/constants/chains.ts
@@ -12,7 +12,7 @@ import { CONFIG } from '@/src/lib/constants/config';
 
 /* SUPPORTED NETWORK TYPES ================================================== */
 
-export const SUPPORTED_CHAIN_ID = [1, 137, 80001] as const;
+export const SUPPORTED_CHAIN_ID = [-1, 137, 80001] as const;
 export type SupportedChainID = (typeof SUPPORTED_CHAIN_ID)[number];
 
 export function isSupportedChainId(
@@ -121,7 +121,7 @@ export const CHAIN_METADATA: ChainList = {
     etherscanApi: 'https://api-testnet.polygonscan.com/api',
   },
   unsupported: {
-    id: 1,
+    id: -1,
     name: 'Unsupported',
     domain: 'L1 Blockchain',
     logo: '',

--- a/src/lib/constants/chains.ts
+++ b/src/lib/constants/chains.ts
@@ -12,7 +12,7 @@ import { CONFIG } from '@/src/lib/constants/config';
 
 /* SUPPORTED NETWORK TYPES ================================================== */
 
-export const SUPPORTED_CHAIN_ID = [-1, 137, 80001] as const;
+export const SUPPORTED_CHAIN_ID = [137, 80001] as const;
 export type SupportedChainID = (typeof SUPPORTED_CHAIN_ID)[number];
 
 export function isSupportedChainId(
@@ -22,9 +22,7 @@ export function isSupportedChainId(
 }
 
 const SUPPORTED_NETWORKS = ['polygon', 'mumbai'] as const;
-export type SupportedNetworks =
-  | (typeof SUPPORTED_NETWORKS)[number]
-  | 'unsupported';
+export type SupportedNetworks = (typeof SUPPORTED_NETWORKS)[number];
 
 export function isSupportedNetwork(
   network: string
@@ -32,10 +30,17 @@ export function isSupportedNetwork(
   return SUPPORTED_NETWORKS.some((n) => n === network);
 }
 
-export function toSupportedNetwork(network: string): SupportedNetworks {
+/**
+ * Check if the given network is supported and return the network name if so
+ * @param network Network name (e.g. 'polygon' or 'mumbai')
+ * @returns the name of the supported network or undefined if network is unsupported
+ */
+export function toSupportedNetwork(
+  network: string
+): SupportedNetworks | undefined {
   return SUPPORTED_NETWORKS.some((n) => n === network)
     ? (network as SupportedNetworks)
-    : 'unsupported';
+    : undefined;
 }
 
 /**
@@ -120,24 +125,12 @@ export const CHAIN_METADATA: ChainList = {
     },
     etherscanApi: 'https://api-testnet.polygonscan.com/api',
   },
-  unsupported: {
-    id: -1,
-    name: 'Unsupported',
-    domain: 'L1 Blockchain',
-    logo: '',
-    explorer: '',
-    testnet: false,
-    rpc: '',
-    nativeCurrency: {
-      name: '',
-      symbol: '',
-      decimals: 18,
-    },
-    etherscanApi: '',
-  },
 };
 
-export const PREFERRED_NETWORK: SupportedNetworks =
-  getSupportedNetworkByChainId(CONFIG.PREFERRED_NETWORK_ID) ?? 'unsupported';
+/** Name of the preferred network (e.g. 'polygon' or 'mumbai') */
+export const PREFERRED_NETWORK: SupportedNetworks | undefined =
+  getSupportedNetworkByChainId(CONFIG.PREFERRED_NETWORK_ID);
 
-export const PREFERRED_NETWORK_METADATA = CHAIN_METADATA[PREFERRED_NETWORK];
+/** Chain data of the preferred network */
+export const PREFERRED_NETWORK_METADATA =
+  CHAIN_METADATA[PREFERRED_NETWORK ?? 'polygon'];

--- a/src/lib/constants/chains.ts
+++ b/src/lib/constants/chains.ts
@@ -12,9 +12,7 @@ import { CONFIG } from '@/src/lib/constants/config';
 
 /* SUPPORTED NETWORK TYPES ================================================== */
 
-export const SUPPORTED_CHAIN_ID = [
-  1, 5, 137, 80001, 42161, 421613, 1337,
-] as const;
+export const SUPPORTED_CHAIN_ID = [1, 137, 80001] as const;
 export type SupportedChainID = (typeof SUPPORTED_CHAIN_ID)[number];
 
 export function isSupportedChainId(

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -6,12 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/** Address of the diamond to be used in production */
+const PROD_DIAMOND_ADDRESS = '0xA51994FA9cE33EC75FdAB6Be3B53fB63A157cB80';
+/** Address of the diamond to be used in development (on Mumbai) */
+const DEV_DIAMOND_ADDRESS = '0xA51994FA9cE33EC75FdAB6Be3B53fB63A157cB80';
+
 export const CONFIG = {
   VERIFICATION_API_URL:
     'https://securesecodao-api.herokuapp.com/verification_api',
   SEARCHSECO_API_URL: 'https://searchseco-api.herokuapp.com/api',
   PR_MERGER_API_URL: 'https://securesecodao-pr-merger.herokuapp.com',
-  DIAMOND_ADDRESS: '0xA51994FA9cE33EC75FdAB6Be3B53fB63A157cB80',
+  DIAMOND_ADDRESS: import.meta.env.DEV
+    ? DEV_DIAMOND_ADDRESS
+    : PROD_DIAMOND_ADDRESS,
   PREFERRED_NETWORK_ID: 80001,
 } as const;
 

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -29,19 +29,18 @@ export const DAO_METADATA = {
   name: 'SecureSECO DAO',
   description:
     'Distributed Autonomous Organization for the SecureSECO project.',
-  discord: 'https://discord.gg/2naUnwE9Y2',
-  links: [
-    {
-      name: 'Discord Server',
+  links: {
+    discord: {
+      label: 'Discord Server',
       url: 'https://discord.gg/2naUnwE9Y2',
     },
-    {
-      name: 'User Documentation',
-      url: 'https://docs.secureseco.org/',
-    },
-    {
-      name: 'SecureSECO Website',
+    website: {
+      label: 'SecureSECO Website',
       url: 'https://secureseco.org/',
     },
-  ],
+    docs: {
+      label: 'User Documentation',
+      url: 'https://docs.secureseco.org/',
+    },
+  },
 } as const;

--- a/src/lib/constants/config.ts
+++ b/src/lib/constants/config.ts
@@ -19,7 +19,10 @@ export const CONFIG = {
   DIAMOND_ADDRESS: import.meta.env.DEV
     ? DEV_DIAMOND_ADDRESS
     : PROD_DIAMOND_ADDRESS,
-  PREFERRED_NETWORK_ID: 80001,
+  PREFERRED_NETWORK_ID: import.meta.env.DEV
+    ? 80001
+    : // Change to polygon (137) when ready for production
+      80001,
 } as const;
 
 export const DAO_METADATA = {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -117,13 +117,13 @@ const Dashboard = () => {
         <div className="flex-col sm:items-end gap-y-6 flex">
           <Logo className="h-28 w-28 hidden sm:block" />
           <div className="flex flex-col items-end">
-            {DAO_METADATA.links.map((link, i) => (
+            {Object.values(DAO_METADATA.links).map((link, i) => (
               <a
                 key={i}
                 href={link.url}
                 className="flex flex-row items-center gap-x-2 rounded-sm font-medium text-primary-highlight ring-ring ring-offset-2 ring-offset-background transition-colors duration-200 hover:text-primary-highlight/80 focus:outline-none focus:ring-1"
               >
-                {link.name}
+                {link.label}
                 <HiArrowTopRightOnSquare className="h-4 w-4 shrink-0" />
               </a>
             ))}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -208,7 +208,7 @@ const Dashboard = () => {
             variant="outline"
             className="flex flex-row items-center gap-x-2"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             to={`${PREFERRED_NETWORK_METADATA.explorer}/token/tokenholderchart/${CONFIG.DIAMOND_ADDRESS}`}
           >
             <p>View all members</p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -65,8 +65,6 @@ const Dashboard = () => {
     memberCount,
   } = useMembers({ limit: 5 });
 
-  const etherscanURL = PREFERRED_NETWORK_METADATA.explorer;
-
   return (
     <div className="grid grid-cols-7 gap-6">
       {/* Card showing metadata about the DAO */}
@@ -87,10 +85,10 @@ const Dashboard = () => {
             <Tooltip>
               <TooltipTrigger className="hover:cursor-help flex flex-row items-center gap-x-1">
                 <HiCube className="h-5 w-5 shrink-0 text-primary" />
-                <p>{import.meta.env.DEV ? 'Mumbai' : 'Polygon'}</p>
+                <p>{PREFERRED_NETWORK_METADATA.name}</p>
               </TooltipTrigger>
               <TooltipContent>
-                Deployed on {import.meta.env.DEV ? 'Mumbai' : 'Polygon'} network
+                Deployed on {PREFERRED_NETWORK_METADATA.name} network
               </TooltipContent>
             </Tooltip>
             <div className="flex flex-row items-center gap-x-1">
@@ -211,7 +209,7 @@ const Dashboard = () => {
             className="flex flex-row items-center gap-x-2"
             target="_blank"
             rel="noreferrer"
-            to={`${etherscanURL}/token/tokenholderchart/${CONFIG.DIAMOND_ADDRESS}`}
+            to={`${PREFERRED_NETWORK_METADATA.explorer}/token/tokenholderchart/${CONFIG.DIAMOND_ADDRESS}`}
           >
             <p>View all members</p>
             <HiArrowRight className="h-5 w-5 shrink-0" />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,11 +9,13 @@
 import Logo from '@/src/components/Logo';
 import { ClaimDailyRewardCard } from '@/src/components/dashboard/ClaimDailyRewardCard';
 import MembersList from '@/src/components/dashboard/MembersList';
+import Diamond from '@/src/components/icons/Diamond';
 import { Address } from '@/src/components/ui/Address';
 import { Card } from '@/src/components/ui/Card';
 import Header from '@/src/components/ui/Header';
 import { Link } from '@/src/components/ui/Link';
 import { DefaultMainCardHeader, MainCard } from '@/src/components/ui/MainCard';
+import { Tooltip, TooltipContent } from '@/src/components/ui/Tooltip';
 import { useDiamondSDKContext } from '@/src/context/DiamondGovernanceSDK';
 import { useDaoTransfers } from '@/src/hooks/useDaoTransfers';
 import { useMembers } from '@/src/hooks/useMembers';
@@ -22,6 +24,7 @@ import { PREFERRED_NETWORK_METADATA } from '@/src/lib/constants/chains';
 import { CONFIG, DAO_METADATA } from '@/src/lib/constants/config';
 import { DaoTransfersList, NewTransferDropdown } from '@/src/pages/Finance';
 import { ProposalCardList } from '@/src/pages/Governance';
+import { TooltipTrigger } from '@radix-ui/react-tooltip';
 import {
   HiArrowRight,
   HiArrowTopRightOnSquare,
@@ -72,20 +75,43 @@ const Dashboard = () => {
         className="relative col-span-full flex shrink flex-col gap-y-6 sm:flex-row justify-between"
       >
         <div className="flex flex-col justify-between gap-y-6">
-          <div className="space-y-8">
-            <Header>{DAO_METADATA.name}</Header>
-            <p className="text-lg font-normal text-highlight-foreground/80">
+          <div className="space-y-4 xs:space-y-8">
+            <Header className="text-4xl xs:text-5xl">
+              {DAO_METADATA.name}
+            </Header>
+            <p className="text-base xs:text-lg font-normal text-highlight-foreground/80">
               {DAO_METADATA.description}
             </p>
           </div>
           <div className="flex flex-col gap-x-6 gap-y-2 text-sm font-normal text-highlight-foreground/80 lg:flex-row lg:items-center">
+            <Tooltip>
+              <TooltipTrigger className="hover:cursor-help flex flex-row items-center gap-x-1">
+                <HiCube className="h-5 w-5 shrink-0 text-primary" />
+                <p>{import.meta.env.DEV ? 'Mumbai' : 'Polygon'}</p>
+              </TooltipTrigger>
+              <TooltipContent>
+                Deployed on {import.meta.env.DEV ? 'Mumbai' : 'Polygon'} network
+              </TooltipContent>
+            </Tooltip>
             <div className="flex flex-row items-center gap-x-1">
-              <HiCube className="h-5 w-5 shrink-0 text-primary" />
-              <p>{import.meta.env.DEV ? 'Mumbai' : 'Polygon'}</p>
+              <Tooltip>
+                <TooltipTrigger className="hover:cursor-help">
+                  <HiHome className="h-5 w-5 shrink-0 text-primary" />
+                </TooltipTrigger>
+                <TooltipContent>DAO address</TooltipContent>
+              </Tooltip>
+              <Address address={daoAddress ?? '...'} showCopy />
             </div>
             <div className="flex flex-row items-center gap-x-1">
-              <HiHome className="h-5 w-5 shrink-0 text-primary" />
-              <Address address={daoAddress ?? '...'} showCopy />
+              <Tooltip>
+                <TooltipTrigger className="hover:cursor-help">
+                  <Diamond className="h-5 w-5 shrink-0 text-primary" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Diamond Governance plugin address
+                </TooltipContent>
+              </Tooltip>
+              <Address address={CONFIG.DIAMOND_ADDRESS} showCopy />
             </div>
           </div>
         </div>

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -195,7 +195,7 @@ const Swap = () => {
       ? nativeBalance.value.gte(estimatedGas)
       : true;
 
-  const onSubmit = (_: IFormInputs) => {
+  const onSubmit = () => {
     setIsSwapping(true);
     toast.contractTransaction(() => performSwap(), {
       success: 'Swap successful',
@@ -222,7 +222,22 @@ const Swap = () => {
           />
         }
       >
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-1">
+          {import.meta.env.DEV && (
+            <p className="text-destructive">
+              You are on the {PREFERRED_NETWORK_METADATA.name} testnet, where
+              DAI does not exist. Use{' '}
+              <a
+                className="underline"
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://app.uniswap.org/#/swap"
+              >
+                WMATIC
+              </a>{' '}
+              instead.
+            </p>
+          )}
           {/* From token */}
           <Label>From:</Label>
           <div className="flex p-4 h-24 bg-popover text-popover-foreground rounded-md border border-input">


### PR DESCRIPTION
# Changes

- [x] Make the diamond address and preferred network chain id in the config conditional based on the prod vs dev environment
- [x] Add diamond address to the header on the dashboard page
- [x] Add tooltips to network, dao address and diamond address to explain what those addresses/texts represent
- [x] Make external links in SecureSECO nav collection open in new tab
- [x] Refactor some small things, including using `PREFERRED_NETWORK_METADATA` instead of manually checking `import.meta.env.DEV` and making the links in `DAO_METADATA` an object so the urls can be more easily accessed, for example to reuse the discord server link in other places without having to rely on an index in the array to always correspond to the discord server link
- [x] Place warning text that the swap uses WMATIC instead of DAI on the testnet
- [x] Fix issue with fetching latest commit hash for merge PR action in new-proposal form where it would not apply to the actual actions passed into the form data
