### PR TITLE
fix: show correct end date for early execution

### DIFF
--- a/src/components/proposal/ProposalHistory.tsx
+++ b/src/components/proposal/ProposalHistory.tsx
@@ -63,7 +63,8 @@ const getProposalMilestones = (proposal: Proposal) => {
       res.push({
         label: 'Succeeded',
         variant: 'done',
-        // If the executionDate is earlier than endDate, there was an early execution, so endDate executionDate is also the end date
+        // If the executionDate is earlier than endDate, there was an early execution, so executionDate is also the end date
+        // Note that in general, the exectionDate will not be defined if the proposal status is unequal to Executed
         date:
           proposal.executionDate &&
           compareAsc(proposal.executionDate, proposal.endDate) === -1

--- a/src/pages/ViewProposal.tsx
+++ b/src/pages/ViewProposal.tsx
@@ -50,6 +50,14 @@ const ViewProposal = () => {
         return 'Starts in ' + countdownText(proposal.startDate);
       case ProposalStatus.Active:
         return 'Ends in ' + countdownText(proposal.endDate);
+      case ProposalStatus.Executed:
+        return (
+          'Executed ' +
+          (proposal.executionDate
+            ? countdownText(proposal.executionDate)
+            : '?') +
+          ' ago'
+        );
       default:
         return 'Ended ' + countdownText(proposal.endDate) + ' ago';
     }


### PR DESCRIPTION
# Type of change
 
Bug fix

#### Does it contain breaking changes?

No

# Description

Fixed a bug where a proposal that was executed early would say something like 'Ended x days ago', where x was based on the `endDate` instead of the `executionDate`. It will now correctly use the `executionDate` to show how long ago the proposal was executed.

# Changes

- [x] Use the `executionDate` instead of `endDate` in the header of the proposal page for proposals that are executed early
- [x] Clarify a comment that explained this kind of situation in the proposal history component
