### PR TITLE
fix: update sdk dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@radix-ui/react-toast": "^1.1.3",
         "@radix-ui/react-toggle": "^1.0.2",
         "@radix-ui/react-tooltip": "^1.0.5",
-        "@secureseco-dao/diamond-governance-sdk": "^1.0.0",
+        "@secureseco-dao/diamond-governance-sdk": "^1.0.2",
         "@tanstack/react-table": "^8.9.1",
         "@tiptap/core": "^2.0.3",
         "@tiptap/extension-link": "^2.0.3",
@@ -6993,9 +6993,9 @@
       }
     },
     "node_modules/@secureseco-dao/diamond-governance-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@secureseco-dao/diamond-governance-sdk/-/diamond-governance-sdk-1.0.0.tgz",
-      "integrity": "sha512-QZaZCVwHlTb7QxLUIwNb8Odat/znScbbRxAtzAtBSo5pP5vZGpsYffBXzXn2LKDWtgtrPzvV7p/5YMcc6RlawA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@secureseco-dao/diamond-governance-sdk/-/diamond-governance-sdk-1.0.2.tgz",
+      "integrity": "sha512-aJFk9aUYK21+zNUM1+Lsyay44tEWkWo0xUTEJ/XtWOvFOBLlkCsQUAOn2oCtFp3h1GDknYKZiQfAwkxrQUw6Jg==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@secureseco-dao/diamond-governance-sdk": "^1.0.0",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-alert-dialog": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.2",
@@ -32,6 +31,7 @@
     "@radix-ui/react-toast": "^1.1.3",
     "@radix-ui/react-toggle": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.5",
+    "@secureseco-dao/diamond-governance-sdk": "^1.0.2",
     "@tanstack/react-table": "^8.9.1",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-link": "^2.0.3",


### PR DESCRIPTION
Update diamond-governance-sdk to version 1.0.2.
Introduces a fix for proposals showing up as pending, which should already be finished